### PR TITLE
Exclude fs-jetpack from vite bundle to make the LocalPolicyYamlLoader work again

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,8 @@ export default defineConfig(({ mode }) => {
                 target: "esnext",
                 rollupOptions: {
                     external: [
-                        "crypto"
+                        "crypto",
+                        "fs-jetpack"
                     ],
                     output: {
                         manualChunks: (id) => {


### PR DESCRIPTION
Currently the LocalPolicyYamlLoader does not work, because apparently fs-jetpack is bundled during bundling and something is broken here. You currently get the following error message:

Uncaught TypeError TypeError: n is not a function

If fs-jetpack is not bundled, it will work again. I have reproduced this locally